### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # CSV Import
 
-Publisher: Splunk \
-Connector Version: 1.1.1 \
-Product Vendor: Splunk \
-Product Name: CSV Import \
+Publisher: Splunk <br>
+Connector Version: 1.1.1 <br>
+Product Vendor: Splunk <br>
+Product Name: CSV Import <br>
 Minimum Product Version: 6.1.0
 
 Ingest CSV files into Phantom
 
 ### Supported Actions
 
-[ingest csv](#action-ingest-csv) - Read contents of a CSV and create artifact \
+[ingest csv](#action-ingest-csv) - Read contents of a CSV and create artifact <br>
 [csv from artifacts](#action-csv-from-artifacts) - Create the csv in the vault from the artifacts of container
 
 ## action: 'ingest csv'
 
 Read contents of a CSV and create artifact
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -50,7 +50,7 @@ summary.total_objects_successful | numeric | | |
 
 Create the csv in the vault from the artifacts of container
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/csvimport.json
+++ b/csvimport.json
@@ -242,5 +242,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/csvimport.json
+++ b/csvimport.json
@@ -15,7 +15,7 @@
     "package_name": "phantom_csvimport",
     "main_module": "csvimport_connector.py",
     "min_phantom_version": "6.1.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "app_wizard_version": "1.0.0",
     "fips_compliant": true,
     "configuration": {},

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Update NOTICE file with updated dependencies
 * Apply pre-commit fixes
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)